### PR TITLE
Fix missing history after failed build

### DIFF
--- a/allure-teamcity-agent/build.gradle
+++ b/allure-teamcity-agent/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     compile 'commons-logging:commons-logging:1.1.3'
     compile 'commons-httpclient:commons-httpclient:3.1'
     compile 'org.apache.commons:commons-compress:1.16.1'
+    compile ('org.jetbrains.teamcity:teamcity-rest-client:1.7.26') {
+        exclude group: 'org.slf4j'
+    }
 
     provided 'com.intellij:openapi:7.0.3'
     provided 'org.jetbrains.teamcity:agent-api:9.1'


### PR DESCRIPTION
### Context

**Problem**
    If Allure Report step was skipped during build, the report generated in the next build has empty history of previous runs.

**Preconditions**
    * Build config has multiple steps.
    * There is a step that generates input data for "Allure Report".
    * The following step is "Allure Report" step. It executes only "If all previous steps finished successfully".
    -
    * Run build. Some step before "Allure Report" fails (for example, project can't be built). The build comes to state "Failed". The easy way to represent the case: set small enough build duration limit in "Failure Conditions".
    * Step "Allure Report" is skipped. No report is generated. History is not saved.
    -
    * The next build completes with status "Successful".
    * On "Allure Report" step plugin tries to take history from ".lastFinished". The history isn't saved in .lastFinished because last build skipped "Allure Report".
    * Plugin generates report without history.

**Expected behaviour**
    * Plugin takes history of previous builds and generates report with full history of previous runs.

**Actual behaviour**
    * Plugin can't find history and generates empty history report. History of previous runs is lost. QA engineers are unable to figure out quickly if test was flaky all the time or it fails because new defect was introduced actually.

**Solution implemented in this PR**
    Obtain history from ".lastSuccessful" instead of ".lastFinished".

**Alternative solution (to be discussed)**
    Implement fallback logic: if there is no history in ".lastFinished", try to get it from ".lastSuccessful"

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2