### PR TITLE
Allow loading allure plugin on secondary TeamCity nodes

### DIFF
--- a/allure-teamcity-server/teamcity-plugin.xml
+++ b/allure-teamcity-server/teamcity-plugin.xml
@@ -13,5 +13,5 @@
             <url>https://github.com/allure-framework</url>
         </vendor>
     </info>
-    <deployment use-separate-classloader="true"/>
+    <deployment use-separate-classloader="true" node-responsibilities-aware="true"/>
 </teamcity-plugin>


### PR DESCRIPTION
TeamCity CI supports multi-node installations. By default, the TeamCity cluster may have one main node and many secondary nodes. Secondary nodes require a special attribute in the plugin descriptor which allows loading the plugin on the secondary node. This is required since
- when a plugin has some state in the external system it may cause various issues if the plugin will work on both nodes in parallel.
- TeamCity secondary nodes have configured security manager which may block some network and file operations unless these operations were explicitly allowed.

See TeamCity documentation for details:
https://plugins.jetbrains.com/docs/teamcity/plugin-development-faq.html#How+to+adapt+plugin+for+secondary+node
https://www.jetbrains.com/help/teamcity/multinode-setup.html

At the same time, not loaded plugin causes various issues on the secondary node, for example:
https://youtrack.jetbrains.com/issue/TW-71538
https://youtrack.jetbrains.com/issue/TW-71544

I reviewed the code of the allure plugin and didn't find any problem related to work in a multi-node setup. Looks like one can safely enable this plugin on TeamCity secondary nodes.